### PR TITLE
Add 3MF processing API with Backblaze B2 upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
-﻿# Api server
+# 3MF Processing API
+
+This project provides an Express-based API that accepts `.gcode.3mf` files, converts them to ZIP, reads metadata, returns the `plate_1` image and the `plate.gcode` contents, and uploads the ZIP archive to Backblaze B2.
+
+## Setup
+
+1. **Install dependencies**
+
+   ```bash
+   npm install
+   ```
+
+2. **Configure Backblaze B2 credentials**
+
+   Set environment variables for your B2 account:
+
+   ```bash
+   export B2_KEY_ID="your-key-id"
+   export B2_APPLICATION_KEY="your-application-key"
+   export B2_BUCKET_ID="your-bucket-id"
+   ```
+
+3. **Run the server**
+
+   ```bash
+   npm start
+   ```
+
+## API Usage
+
+Send a `POST` request to `/process-file` with form-data containing the uploaded `.gcode.3mf` file under the `file` field. The API responds with JSON including parsed metadata, a Base64 image `plate_1`, and the `plate.gcode` text.
+
+## Backblaze B2 Hosting
+
+Backblaze B2 is used for storing the processed ZIP file. This API uploads the converted archive to the specified B2 bucket during processing. The API itself should be deployed on your preferred runtime (e.g., a cloud VM or container service) with network access to Backblaze B2.
+
+## Testing
+
+Run unit tests and lint checks:
+
+```bash
+npm test
+npm run lint
+```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,10 @@
+export default [
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: 'module'
+    },
+    rules: {}
+  }
+];

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "mto-express",
+  "version": "1.0.0",
+  "description": "API for processing 3D printer .gcode.3mf files",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node src/index.js",
+    "test": "node --test",
+    "lint": "eslint ."
+  },
+  "keywords": [
+    "3mf",
+    "gcode",
+    "backblaze"
+  ],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "adm-zip": "^0.5.12",
+    "backblaze-b2": "^2.0.0",
+    "express": "^4.19.2",
+    "multer": "^1.4.5",
+    "xml2js": "^0.6.2"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.1"
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,53 @@
+import express from 'express';
+import multer from 'multer';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import AdmZip from 'adm-zip';
+import B2 from 'backblaze-b2';
+import { parseMetadata } from './metadataUtils.js';
+
+const app = express();
+const upload = multer({ dest: 'uploads/' });
+
+const b2 = new B2({
+  applicationKeyId: process.env.B2_KEY_ID,
+  applicationKey: process.env.B2_APPLICATION_KEY
+});
+
+async function uploadToB2(filePath) {
+  await b2.authorize();
+  const { data: uploadData } = await b2.getUploadUrl({ bucketId: process.env.B2_BUCKET_ID });
+  const fileName = path.basename(filePath);
+  await b2.uploadFile({
+    uploadUrl: uploadData.uploadUrl,
+    uploadAuthToken: uploadData.authorizationToken,
+    fileName,
+    data: await fs.readFile(filePath),
+    mime: 'application/zip'
+  });
+}
+
+app.post('/process-file', upload.single('file'), async (req, res) => {
+  try {
+    const tempPath = req.file.path;
+    const zipPath = `${tempPath}.zip`;
+    await fs.rename(tempPath, zipPath);
+    await uploadToB2(zipPath);
+
+    const zip = new AdmZip(zipPath);
+    const metadataEntry = zip.getEntry('Metadata/metadata.xml') || zip.getEntry('metadata.xml');
+    const metadata = metadataEntry ? parseMetadata(metadataEntry.getData().toString()) : {};
+    const imageEntry = zip.getEntry('Metadata/plate_1.png');
+    const image = imageEntry ? imageEntry.getData().toString('base64') : null;
+    const gcodeEntry = zip.getEntry('plate.gcode');
+    const gcodeData = gcodeEntry ? gcodeEntry.getData().toString() : null;
+
+    res.json({ metadata, image, gcodeData });
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+app.listen(3000, () => {
+  console.log('Server listening on port 3000');
+});

--- a/src/metadataUtils.js
+++ b/src/metadataUtils.js
@@ -1,0 +1,9 @@
+export function parseMetadata(xmlString) {
+  const result = {};
+  const regex = /<([\w:]+)>([^<]+)<\/\1>/g;
+  let match;
+  while ((match = regex.exec(xmlString)) !== null) {
+    result[match[1]] = match[2];
+  }
+  return result;
+}

--- a/test/metadataUtils.test.js
+++ b/test/metadataUtils.test.js
@@ -1,0 +1,8 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { parseMetadata } from '../src/metadataUtils.js';
+
+test('parseMetadata extracts key-value pairs', () => {
+  const xml = '<meta><plate>1</plate><author>John</author></meta>';
+  assert.deepStrictEqual(parseMetadata(xml), { plate: '1', author: 'John' });
+});


### PR DESCRIPTION
## Summary
- add Express endpoint to accept `.gcode.3mf` files, convert to ZIP, parse metadata and return image/gcode
- integrate Backblaze B2 client for uploading processed ZIP files
- add simple metadata parser, unit test and ESLint config

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b6de6a40e48327ae0e22dfc28848fe