### PR TITLE
feat: upload .gcode.3mf archives to Google Cloud Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 3MF Processing API
 
-This project provides an Express-based API that accepts `.gcode.3mf` files, converts them to ZIP, reads metadata, returns the `plate_1` image and the `plate.gcode` contents, and uploads the ZIP archive to Backblaze B2.
+This project provides an Express-based API that accepts `.gcode.3mf` files, converts them to ZIP, reads metadata, returns the `plate_1` image and the `plate.gcode` contents, and uploads the ZIP archive to Google Cloud Storage.
 
 ## Setup
 
@@ -10,14 +10,13 @@ This project provides an Express-based API that accepts `.gcode.3mf` files, conv
    npm install
    ```
 
-2. **Configure Backblaze B2 credentials**
+2. **Configure Google Cloud credentials**
 
-   Set environment variables for your B2 account:
+   Provide credentials for a service account with access to the target bucket and set the bucket name:
 
    ```bash
-   export B2_KEY_ID="your-key-id"
-   export B2_APPLICATION_KEY="your-application-key"
-   export B2_BUCKET_ID="your-bucket-id"
+   export GOOGLE_APPLICATION_CREDENTIALS="/path/to/key.json"
+   export GCLOUD_BUCKET="your-bucket-name"
    ```
 
 3. **Run the server**
@@ -30,9 +29,16 @@ This project provides an Express-based API that accepts `.gcode.3mf` files, conv
 
 Send a `POST` request to `/process-file` with form-data containing the uploaded `.gcode.3mf` file under the `file` field. The API responds with JSON including parsed metadata, a Base64 image `plate_1`, and the `plate.gcode` text.
 
-## Backblaze B2 Hosting
+## Google Cloud Hosting
 
-Backblaze B2 is used for storing the processed ZIP file. This API uploads the converted archive to the specified B2 bucket during processing. The API itself should be deployed on your preferred runtime (e.g., a cloud VM or container service) with network access to Backblaze B2.
+Google Cloud Storage is used for storing the processed ZIP file. You can deploy the API on Google Cloud Run:
+
+```bash
+gcloud builds submit --tag gcr.io/PROJECT_ID/mto-express
+gcloud run deploy mto-express --image gcr.io/PROJECT_ID/mto-express --platform managed --allow-unauthenticated
+```
+
+After deployment, send `POST` requests to the service URL from any program to retrieve metadata, the `plate_1` image, and `plate.gcode` contents.
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mto-express",
   "version": "1.0.0",
-  "description": "API for processing 3D printer .gcode.3mf files",
+  "description": "API for processing 3D printer .gcode.3mf files and uploading to Google Cloud Storage",
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",
@@ -11,14 +11,14 @@
   "keywords": [
     "3mf",
     "gcode",
-    "backblaze"
+    "google-cloud"
   ],
   "author": "",
   "license": "ISC",
   "type": "module",
   "dependencies": {
     "adm-zip": "^0.5.12",
-    "backblaze-b2": "^2.0.0",
+    "@google-cloud/storage": "^7.14.0",
     "express": "^4.19.2",
     "multer": "^1.4.5",
     "xml2js": "^0.6.2"

--- a/src/index.js
+++ b/src/index.js
@@ -3,27 +3,20 @@ import multer from 'multer';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import AdmZip from 'adm-zip';
-import B2 from 'backblaze-b2';
+import { Storage } from '@google-cloud/storage';
 import { parseMetadata } from './metadataUtils.js';
 
 const app = express();
 const upload = multer({ dest: 'uploads/' });
 
-const b2 = new B2({
-  applicationKeyId: process.env.B2_KEY_ID,
-  applicationKey: process.env.B2_APPLICATION_KEY
-});
+const storage = new Storage();
 
-async function uploadToB2(filePath) {
-  await b2.authorize();
-  const { data: uploadData } = await b2.getUploadUrl({ bucketId: process.env.B2_BUCKET_ID });
-  const fileName = path.basename(filePath);
-  await b2.uploadFile({
-    uploadUrl: uploadData.uploadUrl,
-    uploadAuthToken: uploadData.authorizationToken,
-    fileName,
-    data: await fs.readFile(filePath),
-    mime: 'application/zip'
+async function uploadToGcs(filePath) {
+  const bucket = storage.bucket(process.env.GCLOUD_BUCKET);
+  const destination = path.basename(filePath);
+  await bucket.upload(filePath, {
+    destination,
+    metadata: { contentType: 'application/zip' }
   });
 }
 
@@ -32,7 +25,7 @@ app.post('/process-file', upload.single('file'), async (req, res) => {
     const tempPath = req.file.path;
     const zipPath = `${tempPath}.zip`;
     await fs.rename(tempPath, zipPath);
-    await uploadToB2(zipPath);
+    await uploadToGcs(zipPath);
 
     const zip = new AdmZip(zipPath);
     const metadataEntry = zip.getEntry('Metadata/metadata.xml') || zip.getEntry('metadata.xml');


### PR DESCRIPTION
## Summary
- replace Backblaze B2 integration with Google Cloud Storage
- document Google Cloud setup and deployment to Cloud Run

## Testing
- `npm test`
- `npm run lint` *(fails: eslint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b70c85a3888327b390c3cc03d02e40