### PR TITLE
Fix multer dependency version mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "adm-zip": "^0.5.12",
         "express": "^4.19.2",
-        "multer": "^1.4.5-lts.1",
+        "multer": "1.4.5-lts.2",
         "npm": "^11.5.2",
         "xml2js": "^0.6.2"
       },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "adm-zip": "^0.5.12",
     "express": "^4.19.2",
-    "multer": "^1.4.5",
+    "multer": "1.4.5-lts.2",
     "npm": "^11.5.2",
     "xml2js": "^0.6.2"
   },


### PR DESCRIPTION
## Summary
- pin multer to 1.4.5-lts.2 to match package-lock and avoid npm ci errors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7e75b02108327b099c8e24684337a