### PR TITLE
Add PNG image ordering utility and annotate top image

### DIFF
--- a/src/imageOrderUtils.js
+++ b/src/imageOrderUtils.js
@@ -1,0 +1,414 @@
+import { inflateSync, deflateSync } from 'node:zlib';
+
+const pngSignature = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+
+function readUInt32BE(buffer, offset) {
+  return (
+    (buffer[offset] << 24) |
+    (buffer[offset + 1] << 16) |
+    (buffer[offset + 2] << 8) |
+    buffer[offset + 3]
+  ) >>> 0;
+}
+
+function createCrc32Table() {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n += 1) {
+    let c = n;
+    for (let k = 0; k < 8; k += 1) {
+      if ((c & 1) !== 0) {
+        c = 0xedb88320 ^ (c >>> 1);
+      } else {
+        c >>>= 1;
+      }
+    }
+    table[n] = c >>> 0;
+  }
+  return table;
+}
+
+const crc32Table = createCrc32Table();
+
+function crc32(buffer) {
+  let c = 0xffffffff;
+  for (let i = 0; i < buffer.length; i += 1) {
+    c = crc32Table[(c ^ buffer[i]) & 0xff] ^ (c >>> 8);
+  }
+  return (c ^ 0xffffffff) >>> 0;
+}
+
+function applySubFilter(scanline, bytesPerPixel) {
+  for (let i = bytesPerPixel; i < scanline.length; i += 1) {
+    scanline[i] = (scanline[i] + scanline[i - bytesPerPixel]) & 0xff;
+  }
+}
+
+function applyUpFilter(scanline, prior, bytesPerPixel) {
+  if (!prior) {
+    return;
+  }
+  for (let i = 0; i < scanline.length; i += 1) {
+    scanline[i] = (scanline[i] + prior[i]) & 0xff;
+  }
+}
+
+function applyAverageFilter(scanline, prior, bytesPerPixel) {
+  for (let i = 0; i < scanline.length; i += 1) {
+    const left = i >= bytesPerPixel ? scanline[i - bytesPerPixel] : 0;
+    const up = prior ? prior[i] : 0;
+    scanline[i] = (scanline[i] + Math.floor((left + up) / 2)) & 0xff;
+  }
+}
+
+function paethPredictor(a, b, c) {
+  const p = a + b - c;
+  const pa = Math.abs(p - a);
+  const pb = Math.abs(p - b);
+  const pc = Math.abs(p - c);
+
+  if (pa <= pb && pa <= pc) {
+    return a;
+  }
+  if (pb <= pc) {
+    return b;
+  }
+  return c;
+}
+
+function applyPaethFilter(scanline, prior, bytesPerPixel) {
+  for (let i = 0; i < scanline.length; i += 1) {
+    const left = i >= bytesPerPixel ? scanline[i - bytesPerPixel] : 0;
+    const up = prior ? prior[i] : 0;
+    const upLeft = prior && i >= bytesPerPixel ? prior[i - bytesPerPixel] : 0;
+    scanline[i] = (scanline[i] + paethPredictor(left, up, upLeft)) & 0xff;
+  }
+}
+
+function ensureRgbaColorType(ihdr) {
+  const { bitDepth, colorType, compressionMethod, filterMethod, interlaceMethod } = ihdr;
+  if (bitDepth !== 8 || colorType !== 6) {
+    throw new Error('Only 8-bit RGBA PNG images are supported');
+  }
+  if (compressionMethod !== 0 || filterMethod !== 0) {
+    throw new Error('Unsupported PNG compression or filter method');
+  }
+  if (interlaceMethod !== 0) {
+    throw new Error('Interlaced PNG images are not supported');
+  }
+}
+
+export function decodeRgbaPng(buffer) {
+  if (!buffer.subarray(0, 8).equals(pngSignature)) {
+    throw new Error('Invalid PNG signature');
+  }
+
+  let offset = 8;
+  let width = 0;
+  let height = 0;
+  let ihdr;
+  const idatChunks = [];
+
+  while (offset < buffer.length) {
+    const chunkLength = readUInt32BE(buffer, offset);
+    offset += 4;
+    const chunkType = buffer.subarray(offset, offset + 4).toString('ascii');
+    offset += 4;
+    const chunkData = buffer.subarray(offset, offset + chunkLength);
+    offset += chunkLength;
+    offset += 4; // skip CRC
+
+    if (chunkType === 'IHDR') {
+      width = readUInt32BE(chunkData, 0);
+      height = readUInt32BE(chunkData, 4);
+      ihdr = {
+        width,
+        height,
+        bitDepth: chunkData[8],
+        colorType: chunkData[9],
+        compressionMethod: chunkData[10],
+        filterMethod: chunkData[11],
+        interlaceMethod: chunkData[12]
+      };
+    } else if (chunkType === 'IDAT') {
+      idatChunks.push(chunkData);
+    } else if (chunkType === 'IEND') {
+      break;
+    }
+  }
+
+  if (!ihdr) {
+    throw new Error('PNG missing IHDR chunk');
+  }
+
+  ensureRgbaColorType(ihdr);
+
+  const compressedData = Buffer.concat(idatChunks);
+  const decompressed = inflateSync(compressedData);
+  const bytesPerPixel = 4;
+  const stride = width * bytesPerPixel;
+  const result = Buffer.alloc(width * height * bytesPerPixel);
+
+  let srcOffset = 0;
+  let destOffset = 0;
+  let priorScanline = null;
+
+  for (let y = 0; y < height; y += 1) {
+    const filterType = decompressed[srcOffset];
+    srcOffset += 1;
+
+    const scanline = Buffer.from(decompressed.subarray(srcOffset, srcOffset + stride));
+    srcOffset += stride;
+
+    switch (filterType) {
+      case 0:
+        break;
+      case 1:
+        applySubFilter(scanline, bytesPerPixel);
+        break;
+      case 2:
+        applyUpFilter(scanline, priorScanline, bytesPerPixel);
+        break;
+      case 3:
+        applyAverageFilter(scanline, priorScanline, bytesPerPixel);
+        break;
+      case 4:
+        applyPaethFilter(scanline, priorScanline, bytesPerPixel);
+        break;
+      default:
+        throw new Error(`Unsupported PNG filter type: ${filterType}`);
+    }
+
+    scanline.copy(result, destOffset);
+    destOffset += stride;
+    priorScanline = scanline;
+  }
+
+  return { width, height, data: result };
+}
+
+function createChunk(type, data) {
+  const chunkType = Buffer.from(type, 'ascii');
+  const lengthBuffer = Buffer.alloc(4);
+  lengthBuffer.writeUInt32BE(data.length, 0);
+  const crcValue = crc32(Buffer.concat([chunkType, data]));
+  const crcBuffer = Buffer.alloc(4);
+  crcBuffer.writeUInt32BE(crcValue >>> 0, 0);
+  return Buffer.concat([lengthBuffer, chunkType, data, crcBuffer]);
+}
+
+export function encodeRgbaPng({ width, height, data }) {
+  if (data.length !== width * height * 4) {
+    throw new Error('Pixel data size does not match width and height');
+  }
+
+  const ihdrData = Buffer.alloc(13);
+  ihdrData.writeUInt32BE(width, 0);
+  ihdrData.writeUInt32BE(height, 4);
+  ihdrData[8] = 8; // bit depth
+  ihdrData[9] = 6; // RGBA
+  ihdrData[10] = 0; // compression
+  ihdrData[11] = 0; // filter
+  ihdrData[12] = 0; // no interlace
+
+  const bytesPerPixel = 4;
+  const stride = width * bytesPerPixel;
+  const scanlines = Buffer.alloc((stride + 1) * height);
+  let srcOffset = 0;
+  let destOffset = 0;
+
+  for (let y = 0; y < height; y += 1) {
+    scanlines[destOffset] = 0; // filter type 0
+    destOffset += 1;
+    data.copy(scanlines, destOffset, srcOffset, srcOffset + stride);
+    srcOffset += stride;
+    destOffset += stride;
+  }
+
+  const compressed = deflateSync(scanlines, { level: 9 });
+
+  const ihdrChunk = createChunk('IHDR', ihdrData);
+  const idatChunk = createChunk('IDAT', compressed);
+  const iendChunk = createChunk('IEND', Buffer.alloc(0));
+
+  return Buffer.concat([pngSignature, ihdrChunk, idatChunk, iendChunk]);
+}
+
+function colorKey(r, g, b, a) {
+  return `${r},${g},${b},${a}`;
+}
+
+function computeRedIntensity(r, g, b) {
+  return r - (g + b) / 2;
+}
+
+function buildObjectsFromPixels(imageData, { minAlpha = 16 } = {}) {
+  const { width, height, data } = imageData;
+  const objects = new Map();
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const idx = (y * width + x) * 4;
+      const r = data[idx];
+      const g = data[idx + 1];
+      const b = data[idx + 2];
+      const a = data[idx + 3];
+
+      if (a < minAlpha) {
+        continue;
+      }
+
+      const key = colorKey(r, g, b, a);
+      let entry = objects.get(key);
+      if (!entry) {
+        entry = {
+          color: { r, g, b, a },
+          pixelCount: 0,
+          sumX: 0,
+          sumY: 0
+        };
+        objects.set(key, entry);
+      }
+
+      entry.pixelCount += 1;
+      entry.sumX += x;
+      entry.sumY += y;
+    }
+  }
+
+  return Array.from(objects.values())
+    .filter(object => object.pixelCount > 0)
+    .map(object => {
+      const { color, pixelCount, sumX, sumY } = object;
+      const centroid = {
+        x: sumX / pixelCount,
+        y: sumY / pixelCount
+      };
+      const intensity = computeRedIntensity(color.r, color.g, color.b);
+      return {
+        color,
+        pixelCount,
+        centroid,
+        intensity
+      };
+    })
+    .sort((a, b) => {
+      if (b.intensity !== a.intensity) {
+        return b.intensity - a.intensity;
+      }
+      if (b.color.r !== a.color.r) {
+        return b.color.r - a.color.r;
+      }
+      return b.pixelCount - a.pixelCount;
+    })
+    .map((object, index) => ({
+      rank: index + 1,
+      ...object
+    }));
+}
+
+const digitGlyphs = {
+  '0': ['01110', '10001', '10011', '10101', '11001', '10001', '01110'],
+  '1': ['00100', '01100', '00100', '00100', '00100', '00100', '01110'],
+  '2': ['01110', '10001', '00001', '00110', '01000', '10000', '11111'],
+  '3': ['01110', '10001', '00001', '00110', '00001', '10001', '01110'],
+  '4': ['00010', '00110', '01010', '10010', '11111', '00010', '00010'],
+  '5': ['11111', '10000', '11110', '00001', '00001', '10001', '01110'],
+  '6': ['00110', '01000', '10000', '11110', '10001', '10001', '01110'],
+  '7': ['11111', '00001', '00010', '00100', '01000', '01000', '01000'],
+  '8': ['01110', '10001', '10001', '01110', '10001', '10001', '01110'],
+  '9': ['01110', '10001', '10001', '01111', '00001', '00010', '01100']
+};
+
+function setPixel(data, width, x, y, { r, g, b, a }) {
+  if (x < 0 || y < 0 || x >= width || y >= data.length / (width * 4)) {
+    return;
+  }
+  const idx = (y * width + x) * 4;
+  data[idx] = r;
+  data[idx + 1] = g;
+  data[idx + 2] = b;
+  data[idx + 3] = a;
+}
+
+function drawDigit(data, width, startX, startY, digit, color) {
+  const glyph = digitGlyphs[digit];
+  if (!glyph) {
+    return;
+  }
+  for (let row = 0; row < glyph.length; row += 1) {
+    const line = glyph[row];
+    for (let col = 0; col < line.length; col += 1) {
+      if (line[col] === '1') {
+        setPixel(data, width, startX + col, startY + row, color);
+      }
+    }
+  }
+}
+
+function drawLabel(data, width, height, centroid, label) {
+  const digitWidth = 5;
+  const digitHeight = 7;
+  const digitSpacing = 1;
+  const padding = 2;
+  const digits = label.split('');
+  const labelWidth = digits.length * digitWidth + (digits.length - 1) * digitSpacing + padding * 2;
+  const labelHeight = digitHeight + padding * 2;
+
+  const centerX = Math.round(centroid.x);
+  const centerY = Math.round(centroid.y);
+
+  const startX = Math.min(Math.max(centerX - Math.floor(labelWidth / 2), 0), Math.max(width - labelWidth, 0));
+  const startY = Math.min(Math.max(centerY - Math.floor(labelHeight / 2), 0), Math.max(height - labelHeight, 0));
+
+  const backgroundColor = { r: 0, g: 0, b: 0, a: 200 };
+  const textColor = { r: 255, g: 255, b: 255, a: 255 };
+
+  for (let y = 0; y < labelHeight; y += 1) {
+    for (let x = 0; x < labelWidth; x += 1) {
+      setPixel(data, width, startX + x, startY + y, backgroundColor);
+    }
+  }
+
+  let digitOffsetX = startX + padding;
+  const digitOffsetY = startY + padding;
+
+  for (const digit of digits) {
+    drawDigit(data, width, digitOffsetX, digitOffsetY, digit, textColor);
+    digitOffsetX += digitWidth + digitSpacing;
+  }
+}
+
+export function parseObjectOrdering(pickImageBuffer, options = {}) {
+  if (!pickImageBuffer) {
+    return [];
+  }
+  const imageData = decodeRgbaPng(pickImageBuffer);
+  return buildObjectsFromPixels(imageData, options);
+}
+
+export function annotateTopImage(topImageBuffer, orderedObjects) {
+  if (!topImageBuffer) {
+    return null;
+  }
+  const topImageData = decodeRgbaPng(topImageBuffer);
+  const annotatedPixels = Buffer.from(topImageData.data);
+
+  for (const object of orderedObjects) {
+    drawLabel(annotatedPixels, topImageData.width, topImageData.height, object.centroid, String(object.rank));
+  }
+
+  return encodeRgbaPng({ width: topImageData.width, height: topImageData.height, data: annotatedPixels });
+}
+
+export function generateObjectOrdering(pickImageBuffer, topImageBuffer, options = {}) {
+  if (!pickImageBuffer || !topImageBuffer) {
+    return { orderedObjects: [], annotatedImage: null };
+  }
+
+  const orderedObjects = parseObjectOrdering(pickImageBuffer, options.pickOptions);
+  const annotatedImage = orderedObjects.length > 0
+    ? annotateTopImage(topImageBuffer, orderedObjects, options.annotationOptions)
+    : Buffer.from(topImageBuffer);
+
+  return { orderedObjects, annotatedImage };
+}

--- a/test/imageOrderUtils.test.js
+++ b/test/imageOrderUtils.test.js
@@ -1,0 +1,90 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  generateObjectOrdering,
+  parseObjectOrdering,
+  annotateTopImage,
+  encodeRgbaPng,
+  decodeRgbaPng
+} from '../src/imageOrderUtils.js';
+
+function createBlankPixels(width, height, background = { r: 0, g: 0, b: 0, a: 0 }) {
+  const pixels = Buffer.alloc(width * height * 4);
+  for (let i = 0; i < width * height; i += 1) {
+    pixels[i * 4] = background.r;
+    pixels[i * 4 + 1] = background.g;
+    pixels[i * 4 + 2] = background.b;
+    pixels[i * 4 + 3] = background.a;
+  }
+  return pixels;
+}
+
+function paintSquare(buffer, width, xStart, yStart, size, color) {
+  for (let y = 0; y < size; y += 1) {
+    for (let x = 0; x < size; x += 1) {
+      const pixelX = xStart + x;
+      const pixelY = yStart + y;
+      const idx = (pixelY * width + pixelX) * 4;
+      buffer[idx] = color.r;
+      buffer[idx + 1] = color.g;
+      buffer[idx + 2] = color.b;
+      buffer[idx + 3] = color.a;
+    }
+  }
+}
+
+test('parseObjectOrdering ranks objects by red intensity', () => {
+  const width = 8;
+  const height = 8;
+  const pixels = createBlankPixels(width, height);
+
+  paintSquare(pixels, width, 1, 1, 2, { r: 255, g: 0, b: 0, a: 255 });
+  paintSquare(pixels, width, 4, 4, 2, { r: 120, g: 0, b: 0, a: 255 });
+  paintSquare(pixels, width, 2, 5, 2, { r: 20, g: 0, b: 0, a: 255 });
+
+  const pngBuffer = encodeRgbaPng({ width, height, data: pixels });
+  const objects = parseObjectOrdering(pngBuffer);
+
+  assert.equal(objects.length, 3);
+  assert.deepEqual(objects.map(object => object.rank), [1, 2, 3]);
+  assert.ok(objects[0].intensity > objects[1].intensity);
+  assert.ok(objects[1].intensity > objects[2].intensity);
+  assert.ok(objects[0].centroid.x > 0);
+});
+
+test('annotateTopImage overlays numbered labels', () => {
+  const width = 12;
+  const height = 12;
+  const pickPixels = createBlankPixels(width, height);
+  const topPixels = createBlankPixels(width, height, { r: 30, g: 30, b: 30, a: 255 });
+
+  paintSquare(pickPixels, width, 2, 2, 2, { r: 250, g: 0, b: 0, a: 255 });
+  paintSquare(pickPixels, width, 7, 7, 2, { r: 100, g: 0, b: 0, a: 255 });
+
+  const pickBuffer = encodeRgbaPng({ width, height, data: pickPixels });
+  const topBuffer = encodeRgbaPng({ width, height, data: topPixels });
+
+  const { orderedObjects } = generateObjectOrdering(pickBuffer, topBuffer);
+  const annotatedBuffer = annotateTopImage(topBuffer, orderedObjects);
+  const decoded = decodeRgbaPng(annotatedBuffer);
+
+  let whitePixels = 0;
+  let darkPixels = 0;
+  for (let i = 0; i < decoded.data.length; i += 4) {
+    const r = decoded.data[i];
+    const g = decoded.data[i + 1];
+    const b = decoded.data[i + 2];
+    const a = decoded.data[i + 3];
+
+    if (r === 255 && g === 255 && b === 255 && a === 255) {
+      whitePixels += 1;
+    }
+    if (r === 0 && g === 0 && b === 0 && a === 200) {
+      darkPixels += 1;
+    }
+  }
+
+  assert.ok(whitePixels > 0, 'expected numbered glyph pixels to be present');
+  assert.ok(darkPixels > 0, 'expected label background to be present');
+});

--- a/test/processFileHandler.test.js
+++ b/test/processFileHandler.test.js
@@ -4,6 +4,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import AdmZip from 'adm-zip';
+import { encodeRgbaPng, decodeRgbaPng } from '../src/imageOrderUtils.js';
 
 process.env.NODE_ENV = 'test';
 const processFileHandlerPromise = (async () => (await import('../src/index.js')).processFileHandler)();
@@ -40,17 +41,63 @@ test('process-file returns auxiliary metadata assets when available', async () =
   const zip = new AdmZip();
   zip.addFile('Metadata/metadata.xml', Buffer.from('<meta>example</meta>'));
   zip.addFile('Metadata/plate_1.png', Buffer.from('main-image'));
-  zip.addFile('metadata/pick_1.png', Buffer.from('pick-image'));
-  zip.addFile('Metadata/top_1.png', Buffer.from('top-image'));
+  const imageWidth = 10;
+  const imageHeight = 10;
+  const pickPixels = Buffer.alloc(imageWidth * imageHeight * 4);
+  const topPixels = Buffer.alloc(imageWidth * imageHeight * 4, 180);
+
+  function paintSquare(buffer, width, xStart, yStart, size, color) {
+    for (let y = 0; y < size; y += 1) {
+      for (let x = 0; x < size; x += 1) {
+        const pixelX = xStart + x;
+        const pixelY = yStart + y;
+        const idx = (pixelY * width + pixelX) * 4;
+        buffer[idx] = color.r;
+        buffer[idx + 1] = color.g;
+        buffer[idx + 2] = color.b;
+        buffer[idx + 3] = color.a;
+      }
+    }
+  }
+
+  paintSquare(pickPixels, imageWidth, 1, 1, 2, { r: 255, g: 0, b: 0, a: 255 });
+  paintSquare(pickPixels, imageWidth, 5, 5, 2, { r: 120, g: 0, b: 0, a: 255 });
+  paintSquare(pickPixels, imageWidth, 7, 1, 2, { r: 20, g: 0, b: 0, a: 255 });
+
+  const pickImageBuffer = encodeRgbaPng({ width: imageWidth, height: imageHeight, data: pickPixels });
+  const topImageBuffer = encodeRgbaPng({ width: imageWidth, height: imageHeight, data: topPixels });
+
+  zip.addFile('metadata/pick_1.png', pickImageBuffer);
+  zip.addFile('Metadata/top_1.png', topImageBuffer);
   zip.addFile('metadata/slice_info.config', Buffer.from('slice configuration data'));
   zip.addFile('plate.gcode', Buffer.from(';model printing time: 120'));
 
   const response = await invokeHandlerWithBuffer(zip.toBuffer());
 
   assert.equal(response.statusCode, 200);
-  assert.equal(response.payload.pickImage, Buffer.from('pick-image').toString('base64'));
-  assert.equal(response.payload.topImage, Buffer.from('top-image').toString('base64'));
+  assert.equal(response.payload.pickImage, pickImageBuffer.toString('base64'));
+  assert.equal(response.payload.topImage, topImageBuffer.toString('base64'));
   assert.equal(response.payload.sliceInfoConfig, 'slice configuration data');
+  assert.ok(Array.isArray(response.payload.objectOrdering));
+  assert.equal(response.payload.objectOrdering.length, 3);
+  assert.equal(response.payload.objectOrdering[0].rank, 1);
+  assert.equal(response.payload.objectOrdering[0].color.r, 255);
+  assert.ok(typeof response.payload.annotatedTopImage === 'string');
+
+  const annotatedBuffer = Buffer.from(response.payload.annotatedTopImage, 'base64');
+  const decodedAnnotated = decodeRgbaPng(annotatedBuffer);
+  let whitePixelCount = 0;
+  for (let i = 0; i < decodedAnnotated.data.length; i += 4) {
+    if (
+      decodedAnnotated.data[i] === 255 &&
+      decodedAnnotated.data[i + 1] === 255 &&
+      decodedAnnotated.data[i + 2] === 255 &&
+      decodedAnnotated.data[i + 3] === 255
+    ) {
+      whitePixelCount += 1;
+    }
+  }
+  assert.ok(whitePixelCount > 0, 'Annotated image should contain label pixels');
 });
 
 test('process-file omits auxiliary metadata assets when unavailable', async () => {
@@ -64,4 +111,6 @@ test('process-file omits auxiliary metadata assets when unavailable', async () =
   assert.equal(response.payload.pickImage, null);
   assert.equal(response.payload.topImage, null);
   assert.equal(response.payload.sliceInfoConfig, null);
+  assert.deepEqual(response.payload.objectOrdering, []);
+  assert.equal(response.payload.annotatedTopImage, null);
 });


### PR DESCRIPTION
## Summary
- add a PNG image utility that ranks pick image objects by red intensity and renders numeric labels onto the top image
- update the /process-file handler to include ordering data and the annotated image in its response
- cover the new ordering logic and endpoint response with automated tests

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4b3e926d48327884731655533c05d