### PR TITLE
Improve metadata parsing to handle slice info

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,9 @@ export async function processFileHandler(req, res) {
 
     const zip = new AdmZip(zipPath);
     const metadataEntry = zip.getEntry('Metadata/metadata.xml') || zip.getEntry('metadata.xml');
-    const metadata = metadataEntry ? parseMetadata(metadataEntry.getData().toString()) : {};
+    const metadata = metadataEntry
+      ? await parseMetadata(metadataEntry.getData().toString())
+      : { tree: null, plates: [], objects: [] };
     const imageEntry = zip.getEntry('Metadata/plate_1.png');
     const image = imageEntry ? imageEntry.getData().toString('base64') : null;
     const gcodeEntry = zip.getEntry('plate.gcode');

--- a/src/metadataUtils.js
+++ b/src/metadataUtils.js
@@ -1,9 +1,169 @@
-export function parseMetadata(xmlString) {
-  const result = {};
-  const regex = /<([\w:]+)>([^<]+)<\/\1>/g;
-  let match;
-  while ((match = regex.exec(xmlString)) !== null) {
-    result[match[1]] = match[2];
+import { Parser } from 'xml2js';
+
+const parserOptions = {
+  explicitArray: false,
+  attrkey: 'attributes',
+  charkey: 'value',
+  explicitCharkey: true,
+  trim: true
+};
+
+function toArray(value) {
+  if (Array.isArray(value)) {
+    return value;
   }
-  return result;
+  if (value === undefined || value === null) {
+    return [];
+  }
+  return [value];
+}
+
+function extractText(node) {
+  if (node === undefined || node === null) {
+    return '';
+  }
+  if (typeof node === 'string') {
+    return node;
+  }
+  if (Array.isArray(node)) {
+    return node.map(item => extractText(item)).join('').trim();
+  }
+  if (typeof node === 'object' && typeof node.value === 'string') {
+    return node.value;
+  }
+  return '';
+}
+
+function parseSkippedFlag(value) {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  const normalized = String(value).trim().toLowerCase();
+  if (normalized === '' || normalized === '0' || normalized === 'false' || normalized === 'no') {
+    return false;
+  }
+  return normalized === '1' || normalized === 'true' || normalized === 'yes';
+}
+
+function collectObjectNodes(node, collected) {
+  if (Array.isArray(node)) {
+    node.forEach(item => collectObjectNodes(item, collected));
+    return;
+  }
+
+  if (node === undefined || node === null || typeof node !== 'object') {
+    return;
+  }
+
+  if (node.attributes && (node.attributes.identify_id !== undefined || node.attributes.identifyId !== undefined)) {
+    collected.push(node);
+  }
+
+  Object.entries(node).forEach(([key, value]) => {
+    if (key === 'attributes' || key === 'value') {
+      return;
+    }
+    collectObjectNodes(value, collected);
+  });
+}
+
+function buildPlate(plateNode) {
+  const plateAttributes = { ...(plateNode.attributes ?? {}) };
+  const metadataEntries = {};
+
+  const metadataNodes = toArray(plateNode.metadata);
+  metadataNodes.forEach(entry => {
+    if (!entry || typeof entry !== 'object') {
+      return;
+    }
+    const key = entry.attributes?.name ?? entry.attributes?.key ?? entry.attributes?.id;
+    if (!key) {
+      return;
+    }
+    metadataEntries[key] = extractText(entry);
+  });
+
+  const plateObjectsRaw = [];
+  collectObjectNodes(plateNode, plateObjectsRaw);
+
+  const objects = plateObjectsRaw.map(objectNode => {
+    const objectAttributes = { ...(objectNode.attributes ?? {}) };
+    const identifyId = objectAttributes.identify_id ?? objectAttributes.identifyId ?? null;
+    const name = objectAttributes.name ?? null;
+    const skipped = parseSkippedFlag(objectAttributes.skipped);
+
+    return {
+      identifyId,
+      name,
+      skipped,
+      attributes: objectAttributes,
+      raw: objectNode
+    };
+  });
+
+  return {
+    attributes: plateAttributes,
+    metadata: metadataEntries,
+    objects
+  };
+}
+
+function collectPlates(node, plates) {
+  if (Array.isArray(node)) {
+    node.forEach(item => collectPlates(item, plates));
+    return;
+  }
+
+  if (node === undefined || node === null || typeof node !== 'object') {
+    return;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(node, 'plate')) {
+    const plateNodes = toArray(node.plate);
+    plateNodes.forEach(plateNode => {
+      if (plateNode && typeof plateNode === 'object') {
+        plates.push(buildPlate(plateNode));
+        collectPlates(plateNode, plates);
+      }
+    });
+  }
+
+  Object.entries(node).forEach(([key, value]) => {
+    if (key === 'plate' || key === 'attributes' || key === 'value') {
+      return;
+    }
+    collectPlates(value, plates);
+  });
+}
+
+export async function parseMetadata(xmlString) {
+  if (typeof xmlString !== 'string') {
+    return { tree: null, plates: [], objects: [] };
+  }
+
+  const trimmed = xmlString.trim();
+  if (trimmed === '') {
+    return { tree: null, plates: [], objects: [] };
+  }
+
+  let tree;
+  try {
+    const parser = new Parser(parserOptions);
+    tree = await parser.parseStringPromise(trimmed);
+  } catch (error) {
+    return { tree: null, plates: [], objects: [] };
+  }
+
+  const plates = [];
+  collectPlates(tree, plates);
+  const objects = plates.flatMap(plate => plate.objects.map(objectEntry => ({
+    identifyId: objectEntry.identifyId,
+    name: objectEntry.name,
+    skipped: objectEntry.skipped,
+    attributes: objectEntry.attributes,
+    raw: objectEntry.raw,
+    plateIndex: plate.attributes?.index ?? null
+  })));
+
+  return { tree, plates, objects };
 }

--- a/test/metadataUtils.test.js
+++ b/test/metadataUtils.test.js
@@ -1,8 +1,75 @@
 import { test } from 'node:test';
-import assert from 'node:assert';
+import assert from 'node:assert/strict';
 import { parseMetadata } from '../src/metadataUtils.js';
 
-test('parseMetadata extracts key-value pairs', () => {
-  const xml = '<meta><plate>1</plate><author>John</author></meta>';
-  assert.deepStrictEqual(parseMetadata(xml), { plate: '1', author: 'John' });
+test('parseMetadata returns tree, plate metadata, and object summaries', async () => {
+  const xml = `<?xml version="1.0"?>
+    <sliceinfo>
+      <plate index="1">
+        <metadata name="plate_name">Calibration Plate</metadata>
+        <metadata name="plate_no">1</metadata>
+        <object identify_id="OBJ_1" name="Calibration Cube" skipped="0">
+          <settings>
+            <setting name="infill">20</setting>
+          </settings>
+        </object>
+        <object identify_id="OBJ_2" name="Alignment Bar" skipped="1" />
+      </plate>
+    </sliceinfo>`;
+
+  const result = await parseMetadata(xml);
+
+  assert.ok(result.tree.sliceinfo);
+  assert.equal(result.plates.length, 1);
+  assert.deepEqual(result.plates[0].attributes, { index: '1' });
+  assert.deepEqual(result.plates[0].metadata, {
+    plate_name: 'Calibration Plate',
+    plate_no: '1'
+  });
+
+  assert.equal(result.objects.length, 2);
+  assert.deepEqual(result.objects.map(objectEntry => objectEntry.identifyId), ['OBJ_1', 'OBJ_2']);
+  assert.equal(result.objects[0].name, 'Calibration Cube');
+  assert.equal(result.objects[0].skipped, false);
+  assert.equal(result.objects[1].skipped, true);
+});
+
+test('parseMetadata handles nested object containers and attribute variants', async () => {
+  const xml = `
+    <root>
+      <sliceinfo>
+        <plate index="2">
+          <metadata key="plate_name">Multi Plate</metadata>
+          <objects>
+            <object identify_id="OBJ_A" name="Primary" skipped="false" />
+            <object identify_id="OBJ_B" name="Secondary" skipped="true" />
+          </objects>
+        </plate>
+        <plate index="3">
+          <metadata name="plate_name">Second Plate</metadata>
+          <object identifyId="OBJ_C" name="Tertiary" skipped="yes" />
+        </plate>
+      </sliceinfo>
+    </root>`;
+
+  const result = await parseMetadata(xml);
+
+  assert.equal(result.plates.length, 2);
+  assert.deepEqual(result.plates[0].metadata.plate_name, 'Multi Plate');
+  assert.deepEqual(result.plates[1].metadata.plate_name, 'Second Plate');
+
+  const objectById = Object.fromEntries(result.objects.map(objectEntry => [objectEntry.identifyId, objectEntry]));
+  assert.equal(Object.keys(objectById).length, 3);
+  assert.equal(objectById.OBJ_A.skipped, false);
+  assert.equal(objectById.OBJ_B.skipped, true);
+  assert.equal(objectById.OBJ_C.skipped, true);
+  assert.equal(objectById.OBJ_C.plateIndex, '3');
+});
+
+test('parseMetadata returns empty structures for invalid input', async () => {
+  const malformedResult = await parseMetadata('<sliceinfo');
+  assert.deepEqual(malformedResult, { tree: null, plates: [], objects: [] });
+
+  const emptyResult = await parseMetadata('   ');
+  assert.deepEqual(emptyResult, { tree: null, plates: [], objects: [] });
 });


### PR DESCRIPTION
## Summary
- replace the naive metadata regex parser with an xml2js-based parser that preserves attributes and nested nodes
- return full plate metadata and a structured object list with identifyId, name, skipped flags, and plate context
- update and expand metadata utility tests for attribute extraction, nested containers, and invalid input handling

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4b63e6f8883278ceaeb0d22d42324