### PR TITLE
Add model settings parsing and intersection reporting

### DIFF
--- a/src/metadataUtils.js
+++ b/src/metadataUtils.js
@@ -7,3 +7,66 @@ export function parseMetadata(xmlString) {
   }
   return result;
 }
+
+function addIdentifier(targetSet, value) {
+  if (typeof value !== 'string') {
+    return;
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return;
+  }
+  targetSet.add(trimmed);
+}
+
+export function parseModelSettingsObjects(configText) {
+  if (typeof configText !== 'string') {
+    return [];
+  }
+
+  const trimmed = configText.trim();
+  if (trimmed.length === 0) {
+    return [];
+  }
+
+  const identifiers = new Set();
+
+  const collectFromNode = node => {
+    if (Array.isArray(node)) {
+      node.forEach(collectFromNode);
+      return;
+    }
+    if (node && typeof node === 'object') {
+      if (Object.prototype.hasOwnProperty.call(node, 'id')) {
+        addIdentifier(identifiers, node.id);
+      }
+      if (Object.prototype.hasOwnProperty.call(node, 'name')) {
+        addIdentifier(identifiers, node.name);
+      }
+      for (const value of Object.values(node)) {
+        collectFromNode(value);
+      }
+    }
+  };
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    collectFromNode(parsed);
+    if (identifiers.size > 0) {
+      return Array.from(identifiers);
+    }
+  } catch (error) {
+    // Ignore JSON parsing errors and fall back to heuristic parsing.
+  }
+
+  const identifierPattern = /(?:object[_\s.-]*(?:id|name)|\b(?:id|name))\s*[:=]\s*(?:"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|([^\s,;#{}]+))/gi;
+  let match;
+  while ((match = identifierPattern.exec(configText)) !== null) {
+    const value = match[1] ?? match[2] ?? match[3];
+    if (value) {
+      addIdentifier(identifiers, value.replace(/\\"/g, '"').replace(/\\'/g, "'"));
+    }
+  }
+
+  return Array.from(identifiers);
+}

--- a/test/processFileHandler.test.js
+++ b/test/processFileHandler.test.js
@@ -71,6 +71,13 @@ test('process-file returns auxiliary metadata assets when available', async () =
   zip.addFile('Metadata/top_1.png', topImageBuffer);
   zip.addFile('metadata/slice_info.config', Buffer.from('slice configuration data'));
   zip.addFile('plate.gcode', Buffer.from(';model printing time: 120'));
+  const modelSettingsConfig = JSON.stringify({
+    objects: [
+      { id: '1', name: 'Widget A' },
+      { id: '99', name: 'Widget B' }
+    ]
+  });
+  zip.addFile('Metadata/model_settings.config', Buffer.from(modelSettingsConfig));
 
   const response = await invokeHandlerWithBuffer(zip.toBuffer());
 
@@ -78,6 +85,8 @@ test('process-file returns auxiliary metadata assets when available', async () =
   assert.equal(response.payload.pickImage, pickImageBuffer.toString('base64'));
   assert.equal(response.payload.topImage, topImageBuffer.toString('base64'));
   assert.equal(response.payload.sliceInfoConfig, 'slice configuration data');
+  assert.equal(response.payload.modelSettingsConfig, modelSettingsConfig);
+  assert.equal(response.payload.modelSettingsIntersectionCount, 1);
   assert.ok(Array.isArray(response.payload.objectOrdering));
   assert.equal(response.payload.objectOrdering.length, 3);
   assert.equal(response.payload.objectOrdering[0].rank, 1);
@@ -111,6 +120,8 @@ test('process-file omits auxiliary metadata assets when unavailable', async () =
   assert.equal(response.payload.pickImage, null);
   assert.equal(response.payload.topImage, null);
   assert.equal(response.payload.sliceInfoConfig, null);
+  assert.equal(response.payload.modelSettingsConfig, null);
+  assert.equal(response.payload.modelSettingsIntersectionCount, 0);
   assert.deepEqual(response.payload.objectOrdering, []);
   assert.equal(response.payload.annotatedTopImage, null);
 });


### PR DESCRIPTION
## Summary
- load Metadata/model_settings.config using case-insensitive lookup and include the raw text in the API response
- parse model settings files for object identifiers and report how many match detected plate objects
- extend handler tests to cover responses with and without model settings configuration

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4b8880690832792440524e28ee58c