### PR TITLE
Add slice/model config object matching to process handler

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import express from 'express';
 import multer from 'multer';
 import fs from 'node:fs/promises';
 import AdmZip from 'adm-zip';
-import { parseMetadata } from './metadataUtils.js';
+import { parseMetadata, parseSliceInfoConfig, parseModelSettingsConfig } from './metadataUtils.js';
 import { parseGcode } from './gcodeUtils.js';
 import { generateObjectOrdering } from './imageOrderUtils.js';
 
@@ -62,6 +62,63 @@ export async function processFileHandler(req, res) {
     const sliceInfoEntry = getEntryCaseInsensitive(zip, 'Metadata/slice_info.config');
     const sliceInfoConfig = sliceInfoEntry ? sliceInfoEntry.getData().toString() : null;
 
+    const modelSettingsEntry = getEntryCaseInsensitive(zip, 'Metadata/model_settings.config');
+    const modelSettingsConfig = modelSettingsEntry ? modelSettingsEntry.getData().toString() : null;
+
+    const metadataObjects = Array.isArray(metadata.objects) ? metadata.objects : [];
+    const activePlateIds = new Set(
+      metadataObjects
+        .filter(objectEntry => objectEntry && !objectEntry.skipped && objectEntry.identifyId != null)
+        .map(objectEntry => String(objectEntry.identifyId))
+    );
+
+    const sliceInfoParsed = sliceInfoConfig ? await parseSliceInfoConfig(sliceInfoConfig) : { objects: [] };
+    const sliceInfoObjects = Array.isArray(sliceInfoParsed.objects) ? sliceInfoParsed.objects : [];
+    const activeSliceInfoIds = new Set(
+      sliceInfoObjects
+        .filter(objectEntry => objectEntry && !objectEntry.skipped && objectEntry.identifyId != null)
+        .map(objectEntry => String(objectEntry.identifyId))
+    );
+
+    const sliceInfoMatchCount = [...activePlateIds].filter(id => activeSliceInfoIds.has(id)).length;
+
+    const modelSettingsParsed = modelSettingsConfig ? await parseModelSettingsConfig(modelSettingsConfig) : { objects: [] };
+    const modelSettingsObjects = Array.isArray(modelSettingsParsed.objects) ? modelSettingsParsed.objects : [];
+    const activeModelSettingsIds = new Set(
+      modelSettingsObjects
+        .filter(objectEntry => objectEntry && !objectEntry.skipped && objectEntry.identifyId != null)
+        .map(objectEntry => String(objectEntry.identifyId))
+    );
+
+    const modelSettingsMatchCount = [...activePlateIds].filter(id => activeModelSettingsIds.has(id)).length;
+
+    function compareIdentifyIds(a, b) {
+      const parseNumeric = value => {
+        if (value === null || value === undefined) {
+          return Number.POSITIVE_INFINITY;
+        }
+        const match = String(value).match(/-?\d+(?:\.\d+)?/);
+        return match ? Number(match[0]) : Number.POSITIVE_INFINITY;
+      };
+
+      const aNumeric = parseNumeric(a.identifyId);
+      const bNumeric = parseNumeric(b.identifyId);
+      if (aNumeric !== bNumeric) {
+        return aNumeric - bNumeric;
+      }
+      const aId = a.identifyId == null ? '' : String(a.identifyId);
+      const bId = b.identifyId == null ? '' : String(b.identifyId);
+      return aId.localeCompare(bId);
+    }
+
+    const sortedSliceInfoObjects = [...sliceInfoObjects].sort(compareIdentifyIds);
+    const sliceInfoOrderedObjects = sortedSliceInfoObjects.map((objectEntry, index) => ({
+      rank: objectOrdering[index] ? objectOrdering[index].rank : null,
+      identifyId: objectEntry.identifyId ?? null,
+      name: objectEntry.name ?? null,
+      skipped: Boolean(objectEntry.skipped)
+    }));
+
     res.json({
       metadata,
       gcodeInfo,
@@ -70,6 +127,10 @@ export async function processFileHandler(req, res) {
       pickImage,
       topImage,
       sliceInfoConfig,
+      sliceInfoMatchCount,
+      sliceInfoOrderedObjects,
+      modelSettingsConfig,
+      modelSettingsMatchCount,
       objectOrdering,
       annotatedTopImage
     });

--- a/test/metadataUtils.test.js
+++ b/test/metadataUtils.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseMetadata } from '../src/metadataUtils.js';
+import { parseMetadata, parseConfigObjects } from '../src/metadataUtils.js';
 
 test('parseMetadata returns tree, plate metadata, and object summaries', async () => {
   const xml = `<?xml version="1.0"?>
@@ -72,4 +72,24 @@ test('parseMetadata returns empty structures for invalid input', async () => {
 
   const emptyResult = await parseMetadata('   ');
   assert.deepEqual(emptyResult, { tree: null, plates: [], objects: [] });
+});
+
+test('parseConfigObjects extracts object attributes without plate context', async () => {
+  const xml = `<?xml version="1.0"?>
+    <config>
+      <model identify_id="OBJ_10" name="Widget" skipped="false" />
+      <group>
+        <model identifyId="OBJ_20" name="Gadget" skipped="yes" />
+      </group>
+    </config>`;
+
+  const result = await parseConfigObjects(xml);
+
+  assert.equal(result.objects.length, 2);
+  const [first, second] = result.objects;
+  assert.equal(first.identifyId, 'OBJ_10');
+  assert.equal(first.name, 'Widget');
+  assert.equal(first.skipped, false);
+  assert.equal(second.identifyId, 'OBJ_20');
+  assert.equal(second.skipped, true);
 });


### PR DESCRIPTION
## Summary
- extend metadata parsing utilities to handle general object-bearing configs
- update the file processing handler to parse slice/model configs, compute overlap counts, and expose ordered object metadata
- expand tests to cover the new parsing helpers and handler response fields

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4af2d36d483279dc523a59f187ffb